### PR TITLE
Update generator_abacus.py's make_abacus_scf_input() to Support Simultaneous Training of Systems with Different Element Compositions

### DIFF
--- a/deepks/iterate/generator_abacus.py
+++ b/deepks/iterate/generator_abacus.py
@@ -19,8 +19,8 @@ def make_abacus_scf_input(fp_params):
     # Make INPUT file for abacus pw scf calculation.
     ret = "INPUT_PARAMETERS\n"
     ret += "calculation scf\n"
-    assert(fp_params['ntype'] >= 0 and type(fp_params["ntype"]) == int),  "'ntype' should be a positive integer."
-    ret += "ntype %d\n" % fp_params['ntype']
+    # assert(fp_params['ntype'] >= 0 and type(fp_params["ntype"]) == int),  "'ntype' should be a positive integer."
+    # ret += "ntype %d\n" % fp_params['ntype']
     #ret += "pseudo_dir ./\n"
     if "ecutwfc" in fp_params:
         assert(fp_params["ecutwfc"] >= 0) ,  "'ntype' should be non-negative."


### PR DESCRIPTION
ABACUS now supports reading various element types from STRU files, as implemented in the recent update [https://github.com/deepmodeling/abacus-develop/pull/4548]. 
The 'ntype' parameter has been removed from the INPUT file to accommodate a wider range of systems with different element types.