### PR TITLE
Enable model training on Hamiltonian matrix, wavefunction coefficients and energy levels. Supporting for mixed training. Enable some output.

### DIFF
--- a/deepks/iterate/generator_abacus.py
+++ b/deepks/iterate/generator_abacus.py
@@ -84,7 +84,7 @@ def make_abacus_scf_input(fp_params):
         assert(fp_params["deepks_bandgap"] == 0  or fp_params["deepks_bandgap"] == 1), "'deepks_bandgap' should be either 0 or 1."
         ret += "deepks_bandgap %d\n" % fp_params["deepks_bandgap"]
     if "deepks_v_delta" in fp_params:
-        assert(fp_params["deepks_v_delta"] == 0  or fp_params["deepks_v_delta"] == 1), "'deepks_v_delta' should be either 0 or 1."
+        assert(fp_params["deepks_v_delta"] == 0  or fp_params["deepks_v_delta"] == 1 or fp_params["deepks_v_delta"] == 2), "'deepks_v_delta' should be either 0/1/2."
         ret += "deepks_v_delta %d\n" % fp_params["deepks_v_delta"]
     if "model_file" in fp_params:
         ret += "deepks_model %s\n" % fp_params["model_file"]

--- a/deepks/iterate/generator_abacus.py
+++ b/deepks/iterate/generator_abacus.py
@@ -88,6 +88,8 @@ def make_abacus_scf_input(fp_params):
         ret += "deepks_v_delta %d\n" % fp_params["deepks_v_delta"]
     if "model_file" in fp_params:
         ret += "deepks_model %s\n" % fp_params["model_file"]
+    if "out_wfc_lcao" in fp_params:
+        ret += "out_wfc_lcao %s\n" % fp_params["out_wfc_lcao"]
     return ret
 
 def make_abacus_scf_stru(sys_data, fp_pp_files, fp_params):

--- a/deepks/iterate/generator_abacus.py
+++ b/deepks/iterate/generator_abacus.py
@@ -81,8 +81,11 @@ def make_abacus_scf_input(fp_params):
         assert(fp_params["deepks_scf"] == 0  or fp_params["deepks_scf"] == 1), "'deepks_scf' should be either 0 or 1."
         ret += "deepks_scf %d\n" % fp_params["deepks_scf"]
     if "deepks_bandgap" in fp_params:
-        assert(fp_params["deepks_bandgap"] == 0  or fp_params["deepks_bandgap"] == 1), "'deepks_scf' should be either 0 or 1."
+        assert(fp_params["deepks_bandgap"] == 0  or fp_params["deepks_bandgap"] == 1), "'deepks_bandgap' should be either 0 or 1."
         ret += "deepks_bandgap %d\n" % fp_params["deepks_bandgap"]
+    if "deepks_v_delta" in fp_params:
+        assert(fp_params["deepks_v_delta"] == 0  or fp_params["deepks_v_delta"] == 1), "'deepks_v_delta' should be either 0 or 1."
+        ret += "deepks_v_delta %d\n" % fp_params["deepks_v_delta"]
     if "model_file" in fp_params:
         ret += "deepks_model %s\n" % fp_params["model_file"]
     return ret

--- a/deepks/iterate/template.py
+++ b/deepks/iterate/template.py
@@ -448,8 +448,8 @@ def make_train(source_train="data_train", source_test="data_test", *,
         workdir=".", outlog="log.test"
     )
     # concat
-    # seq = [run_train, post_train]
-    seq = [run_train]
+    seq = [run_train, post_train]
+    # seq = [run_train]
     if cleanup:
         clean_train = make_cleanup(
             ["slurm-*.out", "err", "fin.record", "tag_*finished"],

--- a/deepks/iterate/template.py
+++ b/deepks/iterate/template.py
@@ -448,7 +448,8 @@ def make_train(source_train="data_train", source_test="data_test", *,
         workdir=".", outlog="log.test"
     )
     # concat
-    seq = [run_train, post_train]
+    # seq = [run_train, post_train]
+    seq = [run_train]
     if cleanup:
         clean_train = make_cleanup(
             ["slurm-*.out", "err", "fin.record", "tag_*finished"],

--- a/deepks/iterate/template_abacus.py
+++ b/deepks/iterate/template_abacus.py
@@ -72,6 +72,7 @@ DEFAULT_SCF_ARGS_ABACUS={
     "run_cmd": "mpirun",
     "sub_size": 1,
     "abacus_path": "/usr/local/bin/ABACUS.mpi",
+    "out_wfc_lcao": 0,
 }
 
 

--- a/deepks/iterate/template_abacus.py
+++ b/deepks/iterate/template_abacus.py
@@ -404,6 +404,8 @@ def gather_stats_abacus(systems_train, systems_test,
         h_list=[]
         op_list=[]
         vdp_list=[] #v_delta_precalc
+        psialpha_list=[]
+        gevdm_list=[]
         gvx_list=[]
         gvepsl_list=[]
         for f in range(nframes):
@@ -446,9 +448,16 @@ def gather_stats_abacus(systems_train, systems_test,
                 h0_list.append(hcs/2)      
                 hcs=np.load(f"{sys_train_paths[i]}/ABACUS/{f}/h_tot.npy")
                 h_list.append(hcs/2)
-                if os.path.exists(f"{sys_train_paths[i]}/ABACUS/{f}/v_delta_precalc.npy"):
-                    v_delta_precalc=np.load(f"{sys_train_paths[i]}/ABACUS/{f}/v_delta_precalc.npy")
-                    vdp_list.append(v_delta_precalc)              
+                if deepks_v_delta==1:
+                    if os.path.exists(f"{sys_train_paths[i]}/ABACUS/{f}/v_delta_precalc.npy"):
+                        v_delta_precalc=np.load(f"{sys_train_paths[i]}/ABACUS/{f}/v_delta_precalc.npy")
+                        vdp_list.append(v_delta_precalc)
+                elif deepks_v_delta==2:
+                    if os.path.exists(f"{sys_train_paths[i]}/ABACUS/{f}/psialpha.npy") and os.path.exists(f"{sys_train_paths[i]}/ABACUS/{f}/grad_evdm.npy"):
+                        psialpha=np.load(f"{sys_train_paths[i]}/ABACUS/{f}/psialpha.npy")
+                        psialpha_list.append(psialpha)
+                        gevdm=np.load(f"{sys_train_paths[i]}/ABACUS/{f}/grad_evdm.npy")
+                        gevdm_list.append(gevdm)          
         np.save(f"{train_dump}/{sys_train_names[i]}/conv.npy", c_list)
         dm_eig=np.array(d_list)   #concatenate
         np.save(f"{train_dump}/{sys_train_names[i]}/dm_eig.npy", dm_eig)
@@ -495,6 +504,9 @@ def gather_stats_abacus(systems_train, systems_test,
             np.save(f"{train_dump}/{sys_train_names[i]}/h_tot.npy", np.array(h_list))
             if len(vdp_list) > 0:
                 np.save(f"{train_dump}/{sys_train_names[i]}/v_delta_precalc.npy", np.array(vdp_list))
+            elif len(psialpha_list) > 0 and len(gevdm_list) > 0:
+                np.save(f"{train_dump}/{sys_train_names[i]}/psialpha.npy", np.array(psialpha_list))
+                np.save(f"{train_dump}/{sys_train_names[i]}/grad_evdm.npy", np.array(gevdm_list))
             if os.path.exists(f"{sys_train_paths[i]}/overlap.npy"):
                 overlap=np.load(f"{sys_train_paths[i]}/overlap.npy")
                 np.save(f"{train_dump}/{sys_train_names[i]}/overlap.npy", overlap)
@@ -520,6 +532,8 @@ def gather_stats_abacus(systems_train, systems_test,
         h_list=[]
         op_list=[]
         vdp_list=[] #v_delta_precalc
+        psialpha_list=[]
+        gevdm_list=[]        
         gvx_list=[]
         gvepsl_list=[]
         for f in range(nframes):
@@ -562,9 +576,16 @@ def gather_stats_abacus(systems_train, systems_test,
                 h0_list.append(hcs/2)      
                 hcs=np.load(f"{sys_test_paths[i]}/ABACUS/{f}/h_tot.npy")
                 h_list.append(hcs/2)
-                if os.path.exists(f"{sys_test_paths[i]}/ABACUS/{f}/v_delta_precalc.npy"):
-                    v_delta_precalc=np.load(f"{sys_test_paths[i]}/ABACUS/{f}/v_delta_precalc.npy")
-                    vdp_list.append(v_delta_precalc)   
+                if deepks_v_delta==1:
+                    if os.path.exists(f"{sys_test_paths[i]}/ABACUS/{f}/v_delta_precalc.npy"):
+                        v_delta_precalc=np.load(f"{sys_test_paths[i]}/ABACUS/{f}/v_delta_precalc.npy")
+                        vdp_list.append(v_delta_precalc)
+                elif deepks_v_delta==2:
+                    if os.path.exists(f"{sys_test_paths[i]}/ABACUS/{f}/psialpha.npy") and os.path.exists(f"{sys_test_paths[i]}/ABACUS/{f}/grad_evdm.npy"):
+                        psialpha=np.load(f"{sys_test_paths[i]}/ABACUS/{f}/psialpha.npy")
+                        psialpha_list.append(psialpha)
+                        gevdm=np.load(f"{sys_test_paths[i]}/ABACUS/{f}/grad_evdm.npy")
+                        gevdm_list.append(gevdm)   
         dm_eig=np.array(d_list)   #concatenate
         np.save(f"{test_dump}/{sys_test_names[i]}/dm_eig.npy", dm_eig)
         e_base=np.array(e0_list)
@@ -610,6 +631,9 @@ def gather_stats_abacus(systems_train, systems_test,
             np.save(f"{test_dump}/{sys_test_names[i]}/h_tot.npy", np.array(h_list))
             if len(vdp_list) > 0:
                 np.save(f"{test_dump}/{sys_test_names[i]}/v_delta_precalc.npy", np.array(vdp_list))
+            elif len(psialpha_list) > 0 and len(gevdm_list) > 0:
+                np.save(f"{test_dump}/{sys_test_names[i]}/psialpha.npy", np.array(psialpha_list))
+                np.save(f"{test_dump}/{sys_test_names[i]}/grad_evdm.npy", np.array(gevdm_list))
             if os.path.exists(f"{sys_test_paths[i]}/overlap.npy"):
                 overlap=np.load(f"{sys_test_paths[i]}/overlap.npy")
                 np.save(f"{test_dump}/{sys_test_names[i]}/overlap.npy", overlap)

--- a/deepks/iterate/template_abacus.py
+++ b/deepks/iterate/template_abacus.py
@@ -489,12 +489,15 @@ def gather_stats_abacus(systems_train, systems_test,
         if(deepks_v_delta): 
             h_base=np.array(h0_list)
             np.save(f"{train_dump}/{sys_train_names[i]}/h_base.npy", h_base)
-            h_ref=np.load(f"{sys_train_paths[i]}/hamitonian.npy")
-            np.save(f"{train_dump}/{sys_train_names[i]}/hamitonian.npy", h_ref)
+            h_ref=np.load(f"{sys_train_paths[i]}/hamiltonian.npy")
+            np.save(f"{train_dump}/{sys_train_names[i]}/hamiltonian.npy", h_ref)
             np.save(f"{train_dump}/{sys_train_names[i]}/l_h_delta.npy", h_ref-h_base)
             np.save(f"{train_dump}/{sys_train_names[i]}/h_tot.npy", np.array(h_list))
             if len(vdp_list) > 0:
                 np.save(f"{train_dump}/{sys_train_names[i]}/v_delta_precalc.npy", np.array(vdp_list))
+            if os.path.exists(f"{sys_train_paths[i]}/overlap.npy"):
+                overlap=np.load(f"{sys_train_paths[i]}/overlap.npy")
+                np.save(f"{train_dump}/{sys_train_names[i]}/overlap.npy", overlap)
     #concatenate data (test)
     if not os.path.exists(test_dump):
             os.mkdir(test_dump)
@@ -601,12 +604,15 @@ def gather_stats_abacus(systems_train, systems_test,
         if(deepks_v_delta): 
             h_base=np.array(h0_list)
             np.save(f"{test_dump}/{sys_test_names[i]}/h_base.npy", h_base)
-            h_ref=np.load(f"{sys_test_paths[i]}/hamitonian.npy")
-            np.save(f"{test_dump}/{sys_test_names[i]}/hamitonian.npy", h_ref)
+            h_ref=np.load(f"{sys_test_paths[i]}/hamiltonian.npy")
+            np.save(f"{test_dump}/{sys_test_names[i]}/hamiltonian.npy", h_ref)
             np.save(f"{test_dump}/{sys_test_names[i]}/l_h_delta.npy", h_ref-h_base)
             np.save(f"{test_dump}/{sys_test_names[i]}/h_tot.npy", np.array(h_list))
             if len(vdp_list) > 0:
                 np.save(f"{test_dump}/{sys_test_names[i]}/v_delta_precalc.npy", np.array(vdp_list))
+            if os.path.exists(f"{sys_test_paths[i]}/overlap.npy"):
+                overlap=np.load(f"{sys_test_paths[i]}/overlap.npy")
+                np.save(f"{test_dump}/{sys_test_names[i]}/overlap.npy", overlap)
         np.save(f"{test_dump}/{sys_test_names[i]}/conv.npy",c_list)
     #check convergence and print in log
     from deepks.scf.stats import print_stats

--- a/deepks/iterate/template_abacus.py
+++ b/deepks/iterate/template_abacus.py
@@ -172,7 +172,7 @@ def convert_data(systems_train, systems_test=None, *,
             cell_data = np.load(f"{sys_paths[i]}/box.npy")
         nframes = atom_data.shape[0]
         natoms = atom_data.shape[1]
-        atoms = atom_data[1,:,0]
+        atoms = atom_data[0,:,0] # if use atom_data[1,:,0], will need at least two frames
         #atoms.sort() # type order
         types = np.unique(atoms) #index in type list
         ntype = types.size

--- a/deepks/model/reader.py
+++ b/deepks/model/reader.py
@@ -1,7 +1,7 @@
 import os,time,sys
 import numpy as np
 import torch
-import psutil
+# import psutil
 
 def concat_batch(tdicts, dim=0):
     keys = tdicts[0].keys()
@@ -27,9 +27,9 @@ def generalized_eigh(h,L_inv):
     return e,psi
 
 def cal_vdp(psialpha,gevdm):
-    process = psutil.Process(os.getpid())
-    before_memory_usage = process.memory_info().rss
-    start=time.time()
+    # process = psutil.Process(os.getpid())
+    # before_memory_usage = process.memory_info().rss
+    # start=time.time()
 
     v_delta_precalc_temp=torch.einsum("...kyan,...avmn->...kyavm",psialpha,gevdm)
 
@@ -50,12 +50,12 @@ def cal_vdp(psialpha,gevdm):
     vdp=torch.cat(vdp_vector,dim=-1)
     del vdp_vector
 
-    end=time.time()
-    after_memory_usage = process.memory_info().rss
-    memory_growth = after_memory_usage - before_memory_usage
-    print(f"Memory growth during cal vdp: {memory_growth / 1024 / 1024} MB")
+    # end=time.time()
+    # after_memory_usage = process.memory_info().rss
+    # memory_growth = after_memory_usage - before_memory_usage
+    # print(f"Memory growth during cal vdp: {memory_growth / 1024 / 1024} MB")
 
-    print("all cal_vdp time:",end-start)
+    # print("all cal_vdp time:",end-start)
     return vdp
 
 class Reader(object):

--- a/deepks/model/reader.py
+++ b/deepks/model/reader.py
@@ -27,6 +27,7 @@ class Reader(object):
                  f_name="l_f_delta", gvx_name="grad_vx", 
                  s_name="l_s_delta", gvepsl_name="grad_vepsl", 
                  o_name="l_o_delta", op_name="orbital_precalc",
+                 h_name="l_h_delta", vdp_name="v_delta_precalc",
                  eg_name="eg_base", gveg_name="grad_veg", 
                  gldv_name="grad_ldv", conv_name="conv", 
                  atom_name="atom", **kwargs):
@@ -36,10 +37,12 @@ class Reader(object):
         self.f_path = self.check_exist(f_name+".npy")
         self.s_path = self.check_exist(s_name+".npy")
         self.o_path = self.check_exist(o_name+".npy")
+        self.h_path = self.check_exist(h_name+".npy")
         self.d_path = self.check_exist(d_name+".npy")
         self.gvx_path = self.check_exist(gvx_name+".npy")
         self.gvepsl_path = self.check_exist(gvepsl_name+".npy")
         self.op_path = self.check_exist(op_name+".npy")
+        self.vdp_path = self.check_exist(vdp_name+".npy")
         self.eg_path = self.check_exist(eg_name+".npy")
         self.gveg_path = self.check_exist(gveg_name+".npy")
         self.gldv_path = self.check_exist(gldv_name+".npy")
@@ -119,6 +122,17 @@ class Reader(object):
             self.t_data["op"] = torch.tensor(
                 np.load(self.op_path)\
                     .reshape(raw_nframes, -1, self.natm, self.ndesc)[conv])
+        if self.h_path is not None and self.vdp_path is not None:
+            h_shape = np.load(self.h_path).shape
+            assert h_shape[-1] == h_shape[-2], \
+                f"The last two dimension of H must have the same size , which is nlocal"
+            self.nlocal = h_shape[-1]
+            self.t_data["lb_vd"] = torch.tensor(
+                np.load(self.h_path)\
+                  .reshape(raw_nframes, -1, self.nlocal, self.nlocal)[conv]) #-1 for nks
+            self.t_data["vdp"] = torch.tensor(
+                np.load(self.vdp_path)\
+                    .reshape(raw_nframes, -1, self.nlocal, self.nlocal, self.natm, self.ndesc)[conv])
         if self.eg_path is not None and self.gveg_path is not None:
             self.t_data['eg0'] = torch.tensor(
                 np.load(self.eg_path)\

--- a/deepks/model/reader.py
+++ b/deepks/model/reader.py
@@ -26,6 +26,7 @@ def generalized_eigh(h,L_inv):
     psi=L_inv.mT @ v 
     return e,psi
 
+#not used now
 def cal_vdp(psialpha,gevdm):
     # process = psutil.Process(os.getpid())
     # before_memory_usage = process.memory_info().rss

--- a/deepks/model/reader.py
+++ b/deepks/model/reader.py
@@ -176,6 +176,8 @@ class Reader(object):
             self.t_data["lb_vd"] = torch.tensor(
                 np.load(self.h_path)\
                   .reshape(raw_nframes, -1, self.nlocal, self.nlocal)[conv]) #-1 for nks
+            
+            #for v_delta_precalc
             if self.vdp_path is not None and (self.psialpha_path is not None and self.gevdm_path is not None): #both file exist, choose newer ones
                 if os.path.getmtime(self.vdp_path) >= os.path.getmtime(self.psialpha_path):#psialpha and gevdm modified at the same time
                     self.psialpha_path=None
@@ -199,7 +201,8 @@ class Reader(object):
                 # vdp=cal_vdp(psialpha,gevdm)
                 # self.t_data["vdp"] = vdp\
                 #         .reshape(raw_nframes, -1, self.nlocal, self.nlocal, self.natm, self.ndesc)[conv].clone()
-            #for psi labels
+            
+            #for psi labels and band labels
             self.t_data["h_base"]=torch.tensor(
                 np.load(self.h_base_path)\
                   .reshape(raw_nframes, -1, self.nlocal, self.nlocal)[conv]) #-1 for nks
@@ -214,6 +217,8 @@ class Reader(object):
                 band_ref,psi_ref=generalized_eigh(h_ref,L_inv)    
             else:
                 band_ref,psi_ref=torch.linalg.eigh(h_ref,UPLO='U')
+            self.t_data["lb_band"]=band_ref\
+                  .reshape(raw_nframes, -1, self.nlocal)[conv].clone()             
             self.t_data["lb_psi"]=psi_ref\
                   .reshape(raw_nframes, -1, self.nlocal, self.nlocal)[conv].clone()      
         if self.eg_path is not None and self.gveg_path is not None:

--- a/deepks/model/train.py
+++ b/deepks/model/train.py
@@ -154,8 +154,8 @@ class Evaluator:
 
     def __call__(self, model, sample):
         _dref = next(model.parameters())
-        print("_dref:")
-        print(_dref)
+        #print("_dref:")
+        #print(_dref)
         tot_loss = 0.
         loss=[]
         sample = {k: v.to(_dref, non_blocking=True) for k, v in sample.items()}


### PR DESCRIPTION
1. Enable model training on electronic structrue properties:
**only for gamma only now**
- In scf_abacus.yaml : scf_abacus/init_scf_abacus
  - deepks_v_delta=1/2 : In SCF step, ABACUS will output files needed. When deepks_v_delta=2, ABACUS will output psialpha.npy and gevdm.npy instead of v_delta_precalc.npy, which largely save memory.

- In params.yaml : train_input : train_args
  - Hamiltonian loss : Set v_delta_factor.
  - Wavefunction coefficients loss : Set psi_factor and psi_occ. It represents psi loss.
    - psi_occ is the number of psi considered in the loss function. 
    - If you want to set the same psi_occ for all systems, set it as an integer.
    - Also support setting different psi_occ for systems with different atoms. Set psi_occ as a map, with n_atom as the key and the corresponding psi_occ number as value.
  - Energy level loss : Set band_factor and band_occ. Setting for band_occ is similar to psi_occ.
  - Density matrix loss loss : Set density_m_factor and density_m_occ. This loss term may have more physical implications than psi loss.

-  In params.yaml : train_input : data_agrs
   - Psi and energy level are calculated by generalized eigenvalue decomposition, which need to set read_overlap=True. 

2. Support for mixed training:

- In params.yaml : train_input : train_args
  - Enable dividing energy loss with n_atom or n_atom^2. Set energy_per_atom=1/2. energy_per_atom=2 is more often used in mixed training.
  - Enable vd_divide_by_nlocal to make v_delta loss similar in magnitude for systems with different number of atoms. Set vd_divide_by_nlocal=True.

3. Enable some output for clarity

- Output detail loss for each loss term.
- In params.yaml : train_input : train_args
   - Enable output detail test loss for each loss term. Set display_detail_test=True. The factors for these output test loss terms are all one.
   - Enable output train & test loss for systems with different atoms separately. Set display_natom_loss=True. Useful for mixed training.